### PR TITLE
Get-UnProtectedVM to only show VMs with .vmx files on protected datas…

### DIFF
--- a/Meadowcroft.Srm.Protection.ps1
+++ b/Meadowcroft.Srm.Protection.ps1
@@ -48,7 +48,7 @@ Function Get-ProtectionGroup {
             $pgi = $pg.GetInfo()
             $selected = (-not $Name -or ($Name -eq $pgi.Name)) -and (-not $Type -or ($Type -eq $pgi.Type))
             if ($selected) {
-                Add-Member -InputObject $pg -MemberType NoteProperty -Name "Name" -Value $pgi.Name 
+                Add-Member -InputObject $pg -MemberType NoteProperty -Name "Name" -Value $pgi.Name
                 $pg
             }
         }
@@ -95,7 +95,7 @@ Function Get-ProtectedVM {
             try {
                 $_.Vm.UpdateViewData()
             } catch {
-                Write-Error $_            
+                Write-Error $_
             } finally {
                 $_
             }
@@ -145,7 +145,7 @@ Function Get-UnProtectedVM {
             $pds = @(Get-ProtectedDatastore -ProtectionGroup $pg)
             $pds | ForEach-Object {
                 $ds = Get-Datastore -id $_.MoRef
-                $associatedVMs += @(Get-VM -Datastore $ds)
+                $associatedVMs += @(Get-VM -Datastore $ds | Where-Object {$_.extensiondata.config.files.vmpathname -like "*$($ds.name)*"})
             }
         }
 
@@ -359,7 +359,7 @@ Function New-ProtectionGroup {
         if ($pscmdlet.ShouldProcess($Name, "New")) {
             $task = $api.Protection.CreateHbrProtectionGroup($Folder.MoRef, $Name, $Description, $moRefs)
         }
-        
+
     } elseif ($ArrayReplication) {
         #create list of managed object references from VM and/or VM view arrays
         $moRefs = @()
@@ -373,7 +373,7 @@ Function New-ProtectionGroup {
         if ($pscmdlet.ShouldProcess($Name, "New")) {
             $task = $api.Protection.CreateAbrProtectionGroup($Folder.MoRef, $Name, $Description, $moRefs)
         }
-        
+
     } else {
         throw "Undetermined protection group type"
     }
@@ -386,7 +386,7 @@ Function New-ProtectionGroup {
     if ($pg) {
         $unProtectedVMs = Get-UnProtectedVM -ProtectionGroup $pg
         $unProtectedVMs | Protect-VM -ProtectionGroup $pg
-    }      
+    }
 
     return $pg
 }


### PR DESCRIPTION
…tores

If a VM has the .vmx file stored on a non-protected datastore, but has VMDK files located on protected datastores, they do not show up in the SRM GUI, but Get-UnProtectedVM function will show it.  Since they cannot be resolved by Protect-VM, this update filters only VMs that have the .VMX file located on the protected datastores.