### PR TITLE
Get-protecteddatastore full object

### DIFF
--- a/Meadowcroft.Srm.Protection.ps1
+++ b/Meadowcroft.Srm.Protection.ps1
@@ -144,7 +144,7 @@ Function Get-UnProtectedVM {
         if ($pg.GetInfo().Type -eq 'san') {
             $pds = @(Get-ProtectedDatastore -ProtectionGroup $pg)
             $pds | ForEach-Object {
-                $ds = Get-Datastore -id $_.MoRef
+                $ds = $_
                 $associatedVMs += @(Get-VM -Datastore $ds | Where-Object {$_.extensiondata.config.files.vmpathname -like "*$($ds.name)*"})
             }
         }
@@ -182,7 +182,7 @@ Function Get-ProtectedDatastore {
     $ProtectionGroup | ForEach-Object {
         $pg = $_
         if ($pg.GetInfo().Type -eq 'san') { # only supported for array based replication datastores
-            $pg.ListProtectedDatastores()
+            $pg.ListProtectedDatastores() | ForEach-Object {Get-Datastore -Id $_.moref}
         }
     }
 }

--- a/Meadowcroft.Srm.Protection.ps1
+++ b/Meadowcroft.Srm.Protection.ps1
@@ -48,7 +48,7 @@ Function Get-ProtectionGroup {
             $pgi = $pg.GetInfo()
             $selected = (-not $Name -or ($Name -eq $pgi.Name)) -and (-not $Type -or ($Type -eq $pgi.Type))
             if ($selected) {
-                Add-Member -InputObject $pg -MemberType NoteProperty -Name "Name" -Value $pgi.Name 
+                Add-Member -InputObject $pg -MemberType NoteProperty -Name "Name" -Value $pgi.Name
                 $pg
             }
         }
@@ -95,7 +95,7 @@ Function Get-ProtectedVM {
             try {
                 $_.Vm.UpdateViewData()
             } catch {
-                Write-Error $_            
+                Write-Error $_
             } finally {
                 $_
             }
@@ -145,7 +145,7 @@ Function Get-UnProtectedVM {
             $pds = @(Get-ProtectedDatastore -ProtectionGroup $pg)
             $pds | ForEach-Object {
                 $ds = Get-Datastore -id $_.MoRef
-                $associatedVMs += @(Get-VM -Datastore $ds)
+                $associatedVMs += @(Get-VM -Datastore $ds | Where-Object {$_.extensiondata.config.files.vmpathname -like "*$($ds.name)*"})
             }
         }
 
@@ -359,7 +359,7 @@ Function New-ProtectionGroup {
         if ($pscmdlet.ShouldProcess($Name, "New")) {
             $task = $api.Protection.CreateHbrProtectionGroup($Folder.MoRef, $Name, $Description, $moRefs)
         }
-        
+
     } elseif ($ArrayReplication) {
         #create list of managed object references from VM and/or VM view arrays
         $moRefs = @()
@@ -373,7 +373,7 @@ Function New-ProtectionGroup {
         if ($pscmdlet.ShouldProcess($Name, "New")) {
             $task = $api.Protection.CreateAbrProtectionGroup($Folder.MoRef, $Name, $Description, $moRefs)
         }
-        
+
     } else {
         throw "Undetermined protection group type"
     }
@@ -386,7 +386,7 @@ Function New-ProtectionGroup {
     if ($pg) {
         $unProtectedVMs = Get-UnProtectedVM -ProtectionGroup $pg
         $unProtectedVMs | Protect-VM -ProtectionGroup $pg
-    }      
+    }
 
     return $pg
 }


### PR DESCRIPTION
Get-ProtectedDatastore to return full datastore object

MallocArray committed
886ae6d
1 changed file
The $pg.ListProtectedDatastores() command returns an object with type
VMware.Vim.Datastore
and is incomplete, including the name of the datastore. Only the MoRefID is of any use. Piping this to Get-Datastore inside the get-protecteddatastore function returns fully usable datastore types, such as
VMware.VimAutomation.ViCore.Impl.V1.DatastoreManagement.NasDatastoreImpl
VMware.VimAutomation.ViCore.Impl.V1.DatastoreManagement.VmfsDatastoreImpl
VMware.VimAutomation.ViCore.Impl.V1.DatastoreManagement.DatastoreImpl
The only place this is referenced in the module is Get-UnProtectedVM which has been modified as well.

This would break scripts users have written to use Get-ProtectedDatastore if they are doing a similar method of piping the output to Get-Datastore in their script, but this change seems to be more what would be expected output from the function.